### PR TITLE
Replace months_old with age

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ follow a link to a form where they can enter a puppy's information, and, upon
 submission, view the puppy's information.
 
 1. Build out a puppy class in `models/puppy.rb`. Puppies should have `name`,
-   `breed`, and `months_old` attributes. You will need to be able to pass these three
+   `breed`, and `age` attributes. You will need to be able to pass these three
    attributes to initialization, as well as readers or accessors for the attributes.
 
 2. In `app.rb` build out a GET request to load a homepage. The homepage
@@ -29,8 +29,8 @@ submission, view the puppy's information.
 3. The home page will also need a new view `index.erb`. This page should
    welcome you to the Puppy Adoption Site. Add this view to the controller action.
 
-4. Now, we need to create a form for a user to list a new puppy that is
-   available for adoption. You can create this form in `views/create_puppy.erb`.
+4. Now, we need a form for a user to list a new puppy that is
+   available for adoption. You can review this form in `views/create_puppy.erb`.
    Remember, you'll need to set up another controller action for a user to be
    able to view this form in the browser. The "submit" button
    of a form can be an `<input>` element with a `type` of `"submit"` (or a

--- a/spec/models/puppy_spec.rb
+++ b/spec/models/puppy_spec.rb
@@ -26,13 +26,13 @@ describe 'Puppy class' do
     expect(puppy.breed).to eq("black lab")
   end
 
-  it 'can read a puppy age in months (puppy#months_old)' do
-    expect(puppy.months_old).to eq(2)
+  it 'can read a puppy age in months (puppy#age)' do
+    expect(puppy.age).to eq(2)
   end
 
-  it 'can change puppy age in months (puppy#months_old=)' do 
-    puppy.months_old = 3
-    expect(puppy.months_old).to eq(3)
+  it 'can change puppy age in months (puppy#age=)' do 
+    puppy.age = 3
+    expect(puppy.age).to eq(3)
   end
 
   it 'can change puppy name' do

--- a/spec/sinatra_basic_forms_lab_spec.rb
+++ b/spec/sinatra_basic_forms_lab_spec.rb
@@ -35,7 +35,7 @@ describe App do
 
       expect(page).to have_field(:name)
       expect(page).to have_field(:breed)
-      expect(page).to have_field(:months_old)
+      expect(page).to have_field(:age)
     end
   end
 
@@ -46,7 +46,7 @@ describe App do
 
       fill_in(:name, :with => "Butch")
       fill_in(:breed, :with => "Mastiff")
-      fill_in(:months_old, :with => "6")
+      fill_in(:age, :with => "6")
 
       #the below css will match any element (input or button)
       #with a type attribute set to submit
@@ -72,7 +72,7 @@ describe App do
 
       fill_in(:name, :with => "Byron")
       fill_in(:breed, :with => "Poodle")
-      fill_in(:months_old, :with => "9")
+      fill_in(:age, :with => "9")
 
       #the below css will match any element (input or button)
       #with a type attribute set to submit

--- a/views/display_puppy.erb
+++ b/views/display_puppy.erb
@@ -1,5 +1,5 @@
 <body>
-  <p>Puppy Name: <%= @name %></p>
-  <p>Puppy Breed: <%= @breed %></p>
-  <p>Puppy Age: <%= @age %> months</p>
+  <p>Puppy Name: <%= @puppy.name %></p>
+  <p>Puppy Breed: <%= @puppy.breed %></p>
+  <p>Puppy Age: <%= @puppy.age %> months</p>
 </body>


### PR DESCRIPTION
See [this issue](https://github.com/learn-co-curriculum/sinatra-basic-forms-lab/issues/36) for more details. The purpose of this pull request is to eliminate any confusion around the difference of `months_old` and `age` by simply referring to `age` as `age` as per the form in the latest commit. The README has additionally been edited to clarify the state of the form. The `display_puppy.erb` view has been tweaked to refer to a puppy's attributes through a single instance variable instead of three separate instance variables.